### PR TITLE
Set up initial repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # Coding standards
 
-UCL Advanced Research Computing Centre's recommended coding standards for research software projects
+UCL Advanced Research Computing Centre's recommended coding standards for research software projects.
+These are our default assumed style choices unless there are existing project- or domain-specific local style conventions.
 
-  * [C++](cpp)
-  * [Fortran](fortran)
-  * [Java](java)
-  * [Julia](julia)
-  * [MATLAB](matlab)
   * [Python](python)
   * [R](r)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# coding-standards
-ARC's recommended coding standards
+# Coding standards
+
+UCL Advanced Research Computing Centre's recommended coding standards for research software projects
+
+  * [C++](cpp)
+  * [Fortran](fortran)
+  * [Java](java)
+  * [Julia](julia)
+  * [MATLAB](matlab)
+  * [Python](python)
+  * [R](r)

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,7 @@
 # Python
 
-Python code will adhere to the [PEP8](http://legacy.python.org/dev/peps/pep-0008/) Python coding standard.
+Python code should, as a minimum, adhere to the [PEP8](http://legacy.python.org/dev/peps/pep-0008/) Python coding standard.
+We also encourage compliance with modern style recommendations, such as type annotations in [PEP484](https://peps.python.org/pep-0484/).
 
 * As a minimum we will support the last 42 months of Python releases. This has been adopted by the wider scientific Python community and codified in [Numpy Enhancement Proposal 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). If researchers require specific support for older versions of Python this can be offered.
 * We have [separate web pages to document our Python recommendations](https://ucl-arc.github.io/python-tooling/) and we maintain an [ARC-recommended `cookieninja` template](https://github.com/UCL-ARC/python-tooling), which might be a helpful starting point.

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,6 @@
+# Python
+
+Python code will adhere to the [PEP8](http://legacy.python.org/dev/peps/pep-0008/) Python coding standard.
+
+* As a minimum we will support the last 42 months of Python releases. This has been adopted by the wider scientific Python community and codified in [Numpy Enhancement Proposal 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). If researchers require specific support for older versions of Python this can be offered.
+* We have [separate web pages to document our Python recommendations](https://ucl-arc.github.io/python-tooling/) and we maintain an [ARC-recommended `cookieninja` template](https://github.com/UCL-ARC/python-tooling), which might be a helpful starting point.

--- a/r/README.md
+++ b/r/README.md
@@ -1,0 +1,70 @@
+# R recommendations
+
+## Tidyverse style guide
+
+In general, we recommend following the [Tidyverse style guide](https://style.tidyverse.org/) as much
+as possible. There are two R packages that support this style guide out of the box:
+
+* [*styler*](http://styler.r-lib.org/) allows interactively styling selected text, files or entire projects.
+  It includes a handy RStudio plugin to make your R code beautiful with one simple keyboard shortcut
+* [*lintr*](https://github.com/jimhester/lintr) checks whether your code conforms to the style guide and flags
+  potential problems. It can also be enabled in RStudio.
+
+Both these tools can be customised to disable certain checks or using different values. However, we
+recommend sticking to the default values as much as possible.
+
+For VSCode users, the [vscode-R](https://code.visualstudio.com/docs/languages/r) plugin provides most
+of these features in VSCode as well.
+
+> [!NOTE]
+> A note on the use of the pipe (`|>` or `%>%`) operator, although
+>[very useful for data analysis code](https://r4ds.hadley.nz/workflow-style.html#sec-pipes), 
+>we recommend to avoid their usage in **R package code**. The main reason is that pipes make code 
+>more difficult to debug, especially for very long sequences of pipes, as the intermediate objects
+>are not immediately accessible. In addition, the use of `%>%` would incur an additional dependency.
+
+## Package development
+
+The [*R Packages*](https://r-pkgs.org/) book provides a comprehensive guide to R package development,
+which closely follows the *Tidyverse style guide* (as they're from the same authors). We recommend
+following the best practices described in this book.
+
+To help with adhering to these practices and make your life as an R developer much easier, there are
+the [*devtools*](https://devtools.r-lib.org/) and [*usethis*](https://usethis.r-lib.org/) packages.
+From setting up your package file structure with `usethis::create_package()`, running unit tests
+and other checks with `devtools::check()`, to publishing your package to CRAN with `devtools::release()`,
+these two packages have it all covered. In fact, whenever you need to do anything other than edit
+an `*.R` file, there is probably a [*usethis* function](https://usethis.r-lib.org/reference/index.html)
+function you can (and should!) use instead. And if there is not, ask yourself whether you really need
+to do that thing.
+
+And of course, both these packages play nicely together with RStudio, with several built-in features
+and shortcuts (see the *R Packages* book for tips and tricks).
+
+## CI with GitHub Actions
+
+The [r-lib/actions](https://github.com/r-lib/actions) repository contains several reusable *GitHub Actions* (GHA)
+workfklows for R projects (not only packages). The [examples](https://github.com/r-lib/actions/tree/v2/examples)
+directory provides complete workflows for common R project CI tasks. All of these can be easily set up
+using [`usethis::use_github_action()`](https://usethis.r-lib.org/reference/use_github_action.html).
+
+## Bioconductor
+
+When developing an R package for the [Bioconductor project](https://bioconductor.org/), a few exceptions
+to the above recommendations should be considered. Bioconductor provides
+[their own list of recommendations](https://contributions.bioconductor.org/r-code.html). These are
+largely similar to the *Tidyverse style guide*, with a few exceptions:
+
+* Use of 4 spaces for indenting instead of 2
+* Use of `camelCase` for function names
+
+The reason for the latter is that Bioconductor packages make extensive use of the [S4](https://adv-r.hadley.nz/s4)
+OOP framework in R. Within this framework, the convention is to use `CamelCase` for Class names and
+`camelCase` for method names.
+
+The most important of these rules are checked by
+[`BiocCheck::BiocCheck()`](https://bioconductor.org/packages/release/bioc/html/BiocCheck.html)
+The [*biocthis*](https://bioconductor.org/packages/release/bioc/html/biocthis.html) package provides
+a handy alternative to *usethis* for Bioconductor packages. Finally, there is a
+[bioc-actions](https://github.com/grimbough/bioc-actions) with Bioconductor-specific GHA workflows.
+

--- a/r/README.md
+++ b/r/README.md
@@ -68,3 +68,8 @@ The [*biocthis*](https://bioconductor.org/packages/release/bioc/html/biocthis.ht
 a handy alternative to *usethis* for Bioconductor packages. Finally, there is a
 [bioc-actions](https://github.com/grimbough/bioc-actions) with Bioconductor-specific GHA workflows.
 
+The *biocthis* package provides [`biocthis::bioc_style()`](https://lcolladotor.github.io/biocthis/reference/bioc_style.html)
+to configure the *syler* package with the *Bioconductor*-specific rules.
+You can set `options(styler.addins_style_transformer = "biocthis::bioc_style()")` in your `~/.Rprofile`
+to configure these rules globally, or in a project-specific `.Rprofile`.
+


### PR DESCRIPTION
Resolves #2 

Assumes we will have a top-level directory per language, each with an associated `README.md` file describing or linking to the conventions we recommend. As discussed in https://github.com/UCL-ARC/coding-standards/issues/2#issuecomment-1770910877 we can also put other language specific content such as recommended linter configuration files in the relevant directories and link to from the README files.

Currently this has empty `README.md` files for an arbitrary set of languages that I first thought of, other than Python which copies over the existing material from internal documentation. We might want to just remove the empty files and add directories as we add each language, but I'll hold off making changes here till @milanmlft's R recommendations from #8 are merged.