### PR TITLE
Add C++ style guidelines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ effort by needlessly changing to another set of standards.
 
 ## Coding standards by language:
 
+  * [C++](c++)
   * [Python](python)
   * [R](r)
 

--- a/c++/README.md
+++ b/c++/README.md
@@ -1,0 +1,5 @@
+# C++
+
+C++ and C code should conform to the [Google coding conventions](https://google.github.io/styleguide/cppguide.html) in terms of variable names and layout.
+
+We will use [C++11](](http://en.wikipedia.org/wiki/C++11)) features including range-based for loops and lambda expressions where this improves readability.

--- a/c++/README.md
+++ b/c++/README.md
@@ -2,4 +2,21 @@
 
 C++ and C code should conform to the [Google coding conventions](https://google.github.io/styleguide/cppguide.html) in terms of variable names and layout.
 
-We will use [C++11](](http://en.wikipedia.org/wiki/C++11)) features including range-based for loops and lambda expressions where this improves readability.
+We will use modern C++ features - including range-based for loops and lambda expressions - where this improves readability.
+This means we prefer to work with [C++11](](http://en.wikipedia.org/wiki/C++11)), [C++17](http://en.wikipedia.org/wiki/C++17), or newer.
+
+We use the [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) linter configured to obey Google style.
+That is:
+
+```sh
+clang-tidy  --format-style='google'
+```
+
+We also recommend using [cppcheck](https://github.com/cpplint/cpplint), a [static analyser](https://en.wikipedia.org/wiki/Static_program_analysis). It can be helpful to improve code quality in general.
+
+Our preferred build system for C++ code projects is [CMake](https://cmake.org/).
+
+## Further reading
+
+* More pedagogical guidance can be found in C++ course, [PHAS0100: Research Computing with C++](https://github-pages.ucl.ac.uk/research-computing-with-cpp).
+* [ISO C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) - useful resource although less complete than Google's style.


### PR DESCRIPTION
Includes and expands on [our internal documentation](https://github.com/UCL-ARC/research-software-documentation/blob/main/processes/programming_projects/group_practices.md#coding-conventions).

I stuck with Google style because that was in our internal docs and it's what I know and like. If we have a consensus to switch to... something else... I'm fine with that. My opinion is: that we should have a decision that most of us agree with. I don't actually have a very strong opinion about which style to choose.

From the [many many possible tools](https://github.com/UCL-ARC/coding-standards/issues/6#issuecomment-1772483519) I have stuck to a single linter (`clang-tidy`) which is also what we discuss in PHAS0100, and `cppcheck` as a single static analyser. Perhaps obviously, I want to avoid tools that no one in ARC has used or has experience with. We can add to them if we find something that is life-changing. 

@mmcleod89: following our IRL chat last week, there's now some explanation of these guidelines' scope in the [top-level README](https://github.com/UCL-ARC/coding-standards#readme). Anyone who often works in C++ and has an opinion is welcome to join the review. The starting reviewers are C++istas that I've spoken to about this.

## Solves

* #6 