### PR TITLE
Fix broken `[!NOTE]` callout.

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -16,7 +16,6 @@ recommend sticking to the default values as much as possible.
 For VSCode users, the [vscode-R](https://code.visualstudio.com/docs/languages/r) plugin provides most
 of these features in VSCode as well.
 
-> [!NOTE]
 > A note on the use of the pipe (`|>` or `%>%`) operator, although
 >[very useful for data analysis code](https://r4ds.hadley.nz/workflow-style.html#sec-pipes), 
 >we recommend to avoid their usage in **R package code**. The main reason is that pipes make code 


### PR DESCRIPTION
[Some guy made a terrible suggestion](https://github.com/UCL-ARC/coding-standards/pull/8#discussion_r1367225304). Looks like GFM isn't respected by the simple jekyll pages thing we're using.

Sorry!

![Screenshot 2023-10-27 at 10 42 28](https://github.com/UCL-ARC/coding-standards/assets/1836192/4bd37f8b-f3bd-4b9a-8d82-5cf27fd276c1)
