### PR TITLE
Add a link checker.

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,24 @@
+# Check for broken links with lychee
+name: Link Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  link-check:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.8.0
+        with:
+          args: "--verbose -- ."
+          fail: true
+          jobSummary: true


### PR DESCRIPTION
Add a link-checker so we don't accidentally commit a broken URL. (And will flag up when a link becomes outdated.)

## Relates to
* #11

(but does not solve entirely)